### PR TITLE
Update Invoke--Shellcode.ps1

### DIFF
--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -637,16 +637,21 @@ http://www.exploit-monday.com
         if ($Proxy)
         {
             $WebProxyObject = New-Object System.Net.WebProxy
-            $ProxyAddress = (Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyServer
+            $ProxyAddress = (Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -Name 'ProxyServer' -ErrorAction SilentlyContinue)
             
-            # if there is no proxy set, then continue without it
+            # if proxy server exists, set it explicitly
             if ($ProxyAddress) 
             {
-            
                 $WebProxyObject.Address = $ProxyAddress
                 $WebProxyObject.UseDefaultCredentials = $True
                 $WebClientObject.Proxy = $WebProxyObject
             }
+            
+            # otherwise use default credential cache (works for auto configure proxy scripts)
+            else {
+                $WebProxyObject.Credentials = [Net.CredentialCache]::DefaultCredentials;
+            }
+            
         }
 
         try

--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -644,13 +644,14 @@ http://www.exploit-monday.com
             {
                 $WebProxyObject.Address = $ProxyAddress
                 $WebProxyObject.UseDefaultCredentials = $True
-                $WebClientObject.Proxy = $WebProxyObject
             }
             
             # otherwise use default credential cache (works for auto configure proxy scripts)
             else {
                 $WebProxyObject.Credentials = [Net.CredentialCache]::DefaultCredentials;
             }
+            
+            $WebClient.Proxy = $WebProxyObject
             
         }
 

--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -640,9 +640,9 @@ http://www.exploit-monday.com
             $ProxyAddress = (Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -Name 'ProxyServer' -ErrorAction SilentlyContinue)
             
             # if proxy server exists, set it explicitly
-            if ($ProxyAddress) 
+            if ($ProxyAddress -ne $NULL -and $ProxyAddress.ProxyServer -ne $NULL) 
             {
-                $WebProxyObject.Address = $ProxyAddress
+                $WebProxyObject.Address = $ProxyAddress.ProxyServer
                 $WebProxyObject.UseDefaultCredentials = $True
                 $WebClient.Proxy = $WebProxyObject
             }

--- a/CodeExecution/Invoke--Shellcode.ps1
+++ b/CodeExecution/Invoke--Shellcode.ps1
@@ -644,15 +644,13 @@ http://www.exploit-monday.com
             {
                 $WebProxyObject.Address = $ProxyAddress
                 $WebProxyObject.UseDefaultCredentials = $True
+                $WebClient.Proxy = $WebProxyObject
             }
             
             # otherwise use default credential cache (works for auto configure proxy scripts)
             else {
-                $WebProxyObject.Credentials = [Net.CredentialCache]::DefaultCredentials;
+                [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials;
             }
-            
-            $WebClient.Proxy = $WebProxyObject
-            
         }
 
         try


### PR DESCRIPTION
Modified proxy settings to be able to react with "ProxyServer" entry is not set within registry. Then defaults to Net.CredentialCache which will work with automated proxy configurations scripts.